### PR TITLE
Upload cricket_scores python program

### DIFF
--- a/Python/cricket_scores.py
+++ b/Python/cricket_scores.py
@@ -1,0 +1,27 @@
+from tkinter import *
+import time
+import requests
+import json
+
+
+root=Tk()
+
+root.geometry("500x250")
+
+match_data=requests.get('http://cricapi.com/api/cricketScore?unique_id=1216519&apikey=B5fGKy2dzmYwzwswez4mdzbLBpE2')
+json_data=match_data.json()
+
+def times():
+    current_score=json_data['stat']
+    current_score1=json_data['score']
+    score.configure(text="required : "+current_score)
+    score.configure(text="current score : "+current_score1)
+    score.after(200,times)
+
+
+
+score=Label(root,font=("time",15,"bold"),bg="white")
+score.grid(row=2,column=2,pady=25,padx=100)
+times()
+
+root.mainloop()


### PR DESCRIPTION
Display current scores of cricket teams of both live and finalized matches. We need to find out the available matches in cricapi  site and pick out the unique id, api key of match .
We can also work deep to get the detailed information of match.
